### PR TITLE
Remove example key

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add your discord bot token to `src/config/config.ts`:
 
 ```ts
 export let config = {
-  token: "djigoj24gijo-dgj9wdfj", // Discord bot token.
+  token: "xxxxx", // Discord bot token.
   prefix: "!", // Command prefix, ex: !hello
 };
 ```


### PR DESCRIPTION
Not sure if that key was valid or not, but wanted to point it out and suggest replacing it with a placeholder that is more clearly meant to be replaced.